### PR TITLE
Initialize aclk_alert table with history from health log

### DIFF
--- a/database/sqlite/sqlite_aclk.c
+++ b/database/sqlite/sqlite_aclk.c
@@ -522,7 +522,7 @@ void sql_create_aclk_table(RRDHOST *host, uuid_t *host_uuid, uuid_t *node_id)
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 
-    buffer_sprintf(sql,TABLE_ACLK_ALERT, uuid_str);
+    buffer_sprintf(sql,TABLE_ACLK_ALERT, uuid_str, uuid_str, uuid_str);
     db_execute(buffer_tostring(sql));
     buffer_flush(sql);
 //

--- a/database/sqlite/sqlite_aclk.h
+++ b/database/sqlite/sqlite_aclk.h
@@ -94,7 +94,9 @@ static inline char *get_str_from_uuid(uuid_t *uuid)
 
 #define TABLE_ACLK_ALERT "CREATE TABLE IF NOT EXISTS aclk_alert_%s (sequence_id INTEGER PRIMARY KEY, " \
         "alert_unique_id, date_created, date_submitted, " \
-        "unique(alert_unique_id));"
+        "unique(alert_unique_id)); " \
+        "insert into aclk_alert_%s (alert_unique_id, date_created) " \
+        "select unique_id alert_unique_id, strftime('%%s') date_created from health_log_%s where new_status <> 0 order by unique_id asc;"
 
 enum aclk_database_opcode {
     ACLK_DATABASE_NOOP = 0,


### PR DESCRIPTION
When creating the aclk_alert_XXX table, initialize it with current health log, to be queued to cloud.